### PR TITLE
feat: add npm trusted publishing support

### DIFF
--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -2,31 +2,31 @@ name: "Publish package to registry"
 description: "Publishes the package to the registry"
 inputs:
   node-version:
-    description: 'The version of Node.js to use'
+    description: "The version of Node.js to use"
     required: true
   node-cache:
-    description: 'The cache key to use for caching Node.js'
+    description: "The cache key to use for caching Node.js"
     required: false
   package-manager:
-    description: 'The package manager to use'
+    description: "The package manager to use"
     required: false
-    default: 'npm'
+    default: "npm"
   registry-url:
-    description: 'The registry URL to use'
+    description: "The registry URL to use"
     required: false
   artifact-name:
-    description: 'The name of the artifact to download'
+    description: "The name of the artifact to download"
     required: false
-    default: 'package-artifact'
+    default: "package-artifact"
   scope:
-    description: 'The scope to use'
+    description: "The scope to use"
     required: false
-    default: ''
+    default: ""
   auth-token:
-    description: 'The auth token to use'
-    required: true
+    description: "The auth token to use"
+    required: false
   use-public-flag:
-    description: 'Whether to use the public flag'
+    description: "Whether to use the public flag"
     required: false
     default: false
 
@@ -51,7 +51,13 @@ runs:
       shell: bash
       run: tar xf artifact.tar.gz
 
-    - name: Publish
+    - name: Ensure npm supports trusted publishing
+      if: ${{ inputs.auth-token == '' }}
+      shell: bash
+      run: npm install -g npm@latest
+
+    - name: Publish with token
+      if: ${{ inputs.auth-token != '' }}
       shell: bash
       run: |
         if [ "${{ inputs.use-public-flag }}" = "true" ]; then
@@ -61,3 +67,13 @@ runs:
         fi
       env:
         NODE_AUTH_TOKEN: ${{ inputs.auth-token }}
+
+    - name: Publish with OIDC
+      if: ${{ inputs.auth-token == '' }}
+      shell: bash
+      run: |
+        if [ "${{ inputs.use-public-flag }}" = "true" ]; then
+          npm publish --access public
+        else
+          npm publish
+        fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
         uses: ./.github/actions/release
         id: release
         with:
-          node-version: 16
+          node-version: 20
           release-pr-title: 'chore(release): :package: version update for packages'
           release-commit-message: 'chore(release): version update for packages'
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -51,7 +51,7 @@ jobs:
       - name: Prepare
         uses: ./.github/actions/prepare-packages
         with:
-          node-version: 16
+          node-version: 20
           build-command: 'build'
 
   publish-npm:
@@ -59,6 +59,9 @@ jobs:
     needs: prepare
     runs-on: ubuntu-latest
     continue-on-error: false
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Cancel previous jobs
         uses: styfle/cancel-workflow-action@0.11.0
@@ -69,11 +72,10 @@ jobs:
       - name: Publish to NPM
         uses: ./.github/actions/publish
         with:
-          node-version: 16
+          node-version: 20
           registry-url: 'https://registry.npmjs.org/'
           artifact-name: 'package-artifact'
           scope: '@macpaw'
-          auth-token: ${{ secrets.NPM_TOKEN }}
 
   publish-github:
     name: Publish to Github Registry
@@ -90,8 +92,8 @@ jobs:
       - name: Publish to NPM
         uses: ./.github/actions/publish
         with:
-          node-version: 16
-          registry-url: https://npm.pkg.github.com/
+          node-version: 20
+          registry-url: 'https://npm.pkg.github.com/'
           artifact-name: 'package-artifact'
           scope: '@macpaw'
           auth-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add support for npm trusted publishing using OIDC authentication, replacing traditional NPM_TOKEN with secure, short-lived tokens generated by GitHub Actions.

## Changes

- Add `id-token: write` and `contents: read` permissions to `publish-npm` job
- Remove `NPM_TOKEN` from npm publishing workflow
- Upgrade Node.js from 16 to 20 across all jobs
- Update publish action to support both OIDC (for npm) and token-based (for GitHub Packages) authentication
- Add npm upgrade step to ensure trusted publishing support

[npm Trusted Publishers Documentation](https://docs.npmjs.com/trusted-publishers/)