### PR TITLE
feat: migrate to Trusted Publishing for npm packages

### DIFF
--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -24,7 +24,7 @@ inputs:
     default: ''
   auth-token:
     description: 'The auth token to use'
-    required: true
+    required: false
   use-public-flag:
     description: 'Whether to use the public flag'
     required: false
@@ -51,7 +51,12 @@ runs:
       shell: bash
       run: tar xf artifact.tar.gz
 
-    - name: Publish
+    - name: Update npm
+      shell: bash
+      run: npm install -g npm@latest
+
+    - name: Publish (with token)
+      if: ${{ inputs.auth-token != '' }}
       shell: bash
       run: |
         if [ "${{ inputs.use-public-flag }}" = "true" ]; then
@@ -61,3 +66,13 @@ runs:
         fi
       env:
         NODE_AUTH_TOKEN: ${{ inputs.auth-token }}
+
+    - name: Publish (with OIDC)
+      if: ${{ inputs.auth-token == '' }}
+      shell: bash
+      run: |
+        if [ "${{ inputs.use-public-flag }}" = "true" ]; then
+          npm publish --access public
+        else
+          npm publish
+        fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,9 @@ jobs:
     needs: prepare
     runs-on: ubuntu-latest
     continue-on-error: false
+    permissions:
+      id-token: write  # Required for OIDC/Trusted Publishing
+      contents: read   # Required to checkout code
     steps:
       - name: Cancel previous jobs
         uses: styfle/cancel-workflow-action@0.11.0
@@ -73,7 +76,6 @@ jobs:
           registry-url: 'https://registry.npmjs.org/'
           artifact-name: 'package-artifact'
           scope: '@macpaw'
-          auth-token: ${{ secrets.NPM_TOKEN }}
 
   publish-github:
     name: Publish to Github Registry


### PR DESCRIPTION
- Add OIDC permissions (id-token: write) to publish-npm job
- Make auth-token optional in publish action
- Add npm version update to ensure npm 11.5+ for OIDC support
- Separate publish steps for token vs OIDC authentication
- Remove NPM_TOKEN requirement for npm registry publishing
- Add changeset for patch version bump to test release